### PR TITLE
Fix #7, djangobars response imports prevents HandlebarsResponse from import

### DIFF
--- a/djangobars/template/response.py
+++ b/djangobars/template/response.py
@@ -1,5 +1,5 @@
 from django.template.response import TemplateResponse
-from .template import HandlebarsTemplate
+from .base import HandlebarsTemplate
 from .loader import select_template, get_template
 
 


### PR DESCRIPTION
Fixes loading of `HandlebarsResponse` (from the example on README.md)
