### PR TITLE
Template partials

### DIFF
--- a/djangobars/template/base.py
+++ b/djangobars/template/base.py
@@ -6,6 +6,33 @@ try:
 except NameError:
     strtype = str
 
+class PartialList():
+    """
+    If the code references a partial in the template directory, then
+    load and render the template
+    """
+    partials = None
+
+    def __init__(self, partials=None):
+        if partials is not None:
+            self.partials = partials
+        else:
+            self.partials = {}
+
+    def __contains__(self, key):
+        return self.partials.has_key(key)
+
+    def __getitem__(self, partial_name):
+        if not self.partials.has_key(partial_name):
+            from djangobars.template.loader import get_template
+            template = get_template(partial_name)
+            if template:
+                self.partials[partial_name] = template.fn
+        return self.partials.get(partial_name)
+
+    def __setitem__(self, key, val):
+        self.partials[key] = val
+
 
 class HandlebarsTemplate (object):
     PARTIALS = {}
@@ -17,7 +44,7 @@ class HandlebarsTemplate (object):
         self.fn = c.compile(template_string)
         self.name = name
         self.helpers = _djangobars_['helpers'].copy()
-        self.partials = partials
+        self.partials = PartialList(partials)
         
         if is_partial:
             self.partials[name] = self.fn

--- a/setup.py
+++ b/setup.py
@@ -27,8 +27,8 @@ setup(
     url="https://github.com/mjumbewu/djangobars/",
     packages=find_packages(),
     install_requires=[
-        "pymeta",
-        "pybars"
+        "PyMeta3",
+        "pybars3"
     ],
     classifiers=[
         "Development Status :: 3 - Alpha",


### PR DESCRIPTION
with pybars3 accepting: 
https://github.com/wbond/pybars3/commit/562c7df7dbfb8c7e980ecb215e13b29d4e5b52c7

pybars now supports /'s and .'s in a partial's name.  This allows us to leverage the regular file system to lay out and cite templates, including partials, themselves.  This loads partials with Django's standard get_template infrastructure.

This also updates the dependency to pybars3 from pybars with supports python 3 along with bringing in that update.