### PR TITLE
Caching and  thread safety (largeish)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -85,3 +85,26 @@ You can also include Handlebars templates with a Django template tag::
     {% include_handlebars "handlebars_template_name.html" %}
 
 The current template context will be carried over into the Handlebars template.
+
+
+Precompilation
+--------------
+
+You can leverage precompilation supported by pybars 0.9+ by:
+
+1. Add a ``HANDLEBARS_OPTS`` value to your settings module, with a key of ``module_directory``
+   which is an absolute path to where precompiled templates will be written and read from.
+   If ``module_directory`` is set, but ``precompile`` is False, then the templates will
+   not be precompiled but if there are existing precompiled templates in
+   the ``module_directory``, then they will be used.::
+
+       import os
+       import tempfile
+
+       HANDLEBARS_OPTS = {
+          'precompile': True,
+          'module_directory': os.path.join(
+               tempfile.gettempdir(),
+               'djangobars_template_cache')
+       }
+

--- a/djangobars/settings.py
+++ b/djangobars/settings.py
@@ -15,3 +15,7 @@ if hasattr(settings, 'HANDLEBARS_APP_DIRNAMES'):
 
 if hasattr(settings, 'INSTALLED_APPS'):
     INSTALLED_APPS = settings.INSTALLED_APPS
+
+# This is a backwards-compatible way to get OPTIONS previous to Django 1.8
+if hasattr(settings, 'HANDLEBARS_OPTS'):
+    HANDLEBARS_OPTS = settings.HANDLEBARS_OPTS

--- a/djangobars/template/backends.py
+++ b/djangobars/template/backends.py
@@ -1,0 +1,167 @@
+import pybars
+import re
+import sys
+import os
+import shutil
+import tempfile
+
+from django.core.exceptions import ImproperlyConfigured
+from django.template import TemplateDoesNotExist
+
+try:
+    #django 1.8+
+    from django.template.backends import BaseEngine
+except ImportError:
+    BaseEngine = object
+
+try:
+    import threading
+except:
+    import dummy_threading as threading
+
+try:
+    #python3
+    from importlib.machinery import SourceFileLoader
+
+    def sys_load_module(modname, filepath):
+        loader = SourceFileLoader(modname, filepath)
+        return loader.load_module()
+except ImportError:
+    #python2
+    import imp
+
+    def sys_load_module(modname, filepath):
+        try:
+            imp.acquire_lock()
+            mod = imp.load_source(modname, filepath)
+        except:
+            raise
+        finally:
+            imp.release_lock()
+        return mod
+
+
+from .base import HandlebarsTemplate, PartialList
+
+
+class TemplateInformationError(TemplateDoesNotExist):
+    pass
+
+
+class Handlebars(BaseEngine):
+
+    app_dirname = 'handlebars'
+    compiler = pybars.Compiler()
+
+    def __init__(self, params):
+        params = params.copy()
+        options = params.pop('OPTIONS', {}).copy()
+        self.precompile = options.pop('precompile', False)
+        #if module_dir is set we will try to load from there
+        self.module_directory = options.pop('module_directory', False)
+
+        if self.precompile and not self.module_directory:
+            raise ImproperlyConfigured(
+                "A 'module_directory' is required when 'precompile' is True")
+
+        if params:
+            raise ImproperlyConfigured(
+                "Unknown parameters: {}".format(", ".join(params)))
+
+    def get_template(self, template_name, dirs=None):
+        template = None
+        if self.module_directory:
+            template = CompiledTemplate(engine=self,
+                                        template_name=template_name,
+                                        module_directory=self.module_directory,
+                                        template_opts={'dirs': dirs})
+        if not (template and template.fn):
+            if dirs:  # TODO: just assuming its a the loader
+                if hasattr(dirs, 'load_template_source'):
+                    source, display_name = dirs.load_template_source(template_name)
+                    self._debug_template_string = source
+                else:
+                    pass  # TODO: handle actual dirs for Django 1.8
+                template = CompiledTemplate(
+                    template_string=source,
+                    engine=self,
+                    template_name=template_name,
+                    module_directory=self.module_directory,
+                    template_opts={'dirs': dirs})
+        return template
+
+    def from_string(self, template_code, **kwargs):
+        if self.precompile:
+            return CompiledTemplate(template_code)
+        else:
+            return HandlebarsTemplate(template_code, **kwargs)
+
+
+class CompiledTemplate(HandlebarsTemplate):
+
+    def __init__(self, template_string=None, origin=None, name='<Handlebars Template>',
+                 partials=HandlebarsTemplate.PARTIALS, is_partial=True,
+                 engine=None, template_name=None, module_directory=None,
+                 template_opts={}):
+        """
+        This inherits from HandlebarsTemplate and then is mostly replacing the
+        __init__ method.  Instead of compiling just source, we can also
+        compile from template_name, module_directory.
+
+        It's largely meant to be an internal object called by Handlbars engine
+        and the legacy djangobars loaders.
+        """
+        self.fn = None
+        self.template_opts = template_opts
+        if template_string:
+            #1. precompile
+            if template_name and module_directory:
+                if not hasattr(self.compiler, 'precompile'):
+                    raise Exception("You need to upgrade pybars to support precompile.")
+                CompiledTemplate.lock.acquire()
+                full_code = self.compiler.precompile(template_string)
+                CompiledTemplate.lock.release()
+                self.write_module(template_name, module_directory, full_code)
+                self.fn = self.load_module(template_name, module_directory)
+            else:
+                CompiledTemplate.lock.acquire()
+                self.fn = self.compiler.compile(template_string)
+                CompiledTemplate.lock.release()
+        elif template_name and module_directory:
+            #1. just try loading the module
+            self.fn = self.load_module(template_name, module_directory)
+        if not self.fn:
+            return None  # no template
+        if engine is None:
+            raise Exception("engine is a required parameter for CompiledTemplate")
+        self._more_init(name, partials, is_partial, engine)
+
+    def get_template_cache_names(self, template_name, module_directory):
+        filename = template_name.replace('\\', '/').replace('/', '_')
+        filepath = os.path.join(module_directory, '%s.py' % filename)
+        mod_name = 'djangobars._template.%s' % filename
+        return (mod_name, filepath)
+
+    def write_module(self, template_name, module_directory, source_code):
+        mod_name, filepath = self.get_template_cache_names(template_name,
+                                                           module_directory)
+        if not os.path.exists(module_directory):
+            os.makedirs(module_directory)
+        (dest, name) = tempfile.mkstemp(dir=os.path.dirname(filepath))
+        os.write(dest, source_code)
+        os.close(dest)
+        shutil.move(name, filepath)
+
+    def load_module(self, template_name, module_directory):
+        mod_name, filepath = self.get_template_cache_names(template_name,
+                                                           module_directory)
+        if mod_name in sys.modules:
+            mod = sys.modules[mod_name]
+            return mod.render
+        try:
+            mod = sys_load_module(mod_name, filepath)
+            sys.modules[mod_name] = mod
+            return mod.render
+        except IOError, e:
+            #no file found
+            return None

--- a/djangobars/template/base.py
+++ b/djangobars/template/base.py
@@ -6,6 +6,7 @@ try:
 except NameError:
     strtype = str
 
+
 class FakeError(Exception):
     pass
 
@@ -15,6 +16,19 @@ except ImportError:
     PybarsError = FakeError
 
 
+try:
+    import threading
+except:
+    import dummy_threading as threading
+
+
+class FakeEngine(object):
+
+    def get_template(self, template_name, **kwargs):
+        from djangobars.template.loader import get_template
+        return get_template(template_name)
+
+
 class PartialList():
     """
     If the code references a partial in the template directory, then
@@ -22,19 +36,21 @@ class PartialList():
     """
     partials = None
 
-    def __init__(self, partials=None):
+    def __init__(self, partials=None, engine=None, template_opts={}):
         if partials is not None:
             self.partials = partials
         else:
             self.partials = {}
+        self.engine = engine
+        self.template_opts = template_opts
 
     def __contains__(self, key):
         return self.get(key) is not None
 
     def __getitem__(self, partial_name):
         if partial_name not in self.partials:
-            from djangobars.template.loader import get_template
-            template = get_template(partial_name)
+            template = self.engine.get_template(partial_name,
+                                                **self.template_opts)
             if template:
                 self.partials[partial_name] = template.fn
         return self.partials.get(partial_name)
@@ -49,28 +65,44 @@ class PartialList():
 
 class HandlebarsTemplate(object):
     PARTIALS = {}
+    lock = threading.Lock()
+    compiler = pybars.Compiler()
+    template_opts = {}
+    _debug_template_string = ''
 
     def __init__(self, template_string, origin=None,
                  name='<Handlebars Template>',
-                 partials=PARTIALS, is_partial=True):
-        c = pybars.Compiler()
-        self.fn = c.compile(template_string)
+                 partials=PARTIALS, is_partial=True,
+                 engine=None):
+
+        HandlebarsTemplate.lock.acquire()
+        try:
+            self.fn = self.compiler.compile(template_string)
+        except:
+            raise
+        finally:
+            HandlebarsTemplate.lock.release()
+        self._debug_template_string = template_string
+        self._more_init(name, partials, is_partial, engine)
+
+    def _more_init(self, name, partials, is_partial, engine):
         self.name = name
         self.helpers = _djangobars_['helpers'].copy()
-        self.partials = PartialList(partials)
+        self.engine = engine or FakeEngine()
+        self.partials = PartialList(partials, engine=self.engine,
+                                    template_opts=self.template_opts)
 
         if is_partial:
             self.partials[name] = self.fn
 
     def _compile_partial(self, partial_name):
         from djangobars.template.loader import get_template
-        template = get_template(partial_name)
+        template = self.engine.get_template(partial_name, **self.template_opts)
         self.partials[partial_name] = template.fn
 
     def render(self, context):
         if hasattr(context, 'render_context'):
             context.render_context.push()
-
         try:
             s = self.fn(
                 context, helpers=self.helpers, partials=self.partials)
@@ -83,7 +115,7 @@ class HandlebarsTemplate(object):
             #support for Pybars 0.8+
             err = e.message
             if err.startswith('Partial') and err.find('not defined'):
-                partial_name = err[err.index('"')+1:err.rindex('"')]
+                partial_name = err[err.index('"') + 1:err.rindex('"')]
                 self._compile_partial(partial_name)
                 return self.render(context)
             else:

--- a/djangobars/template/loaders/filesystem.py
+++ b/djangobars/template/loaders/filesystem.py
@@ -1,4 +1,5 @@
 from django.template.loaders.filesystem import Loader as CoreLoader
+from django.template.loaders.cached import Loader as DjangoCachedLoader
 from djangobars import settings
 from djangobars.template.loader import BaseHandlebarsLoader
 
@@ -13,3 +14,15 @@ class Loader(BaseHandlebarsLoader, CoreLoader):
         dirs = getattr(settings, 'HANDLEBARS_DIRS', None)
         return super(Loader, self).get_template_sources(template_name,
                                                         template_dirs=dirs)
+
+
+class CachedLoader(DjangoCachedLoader, Loader):
+
+    def __init__(self):
+        self.template_cache = {}
+        self.find_template_cache = {}
+        self._loaders = [Loader()]
+
+    @property
+    def loaders(self):
+        return self._loaders


### PR DESCRIPTION
This is a large-ish patch that adds thread locks where necessary and precompilation support.  I think it's reasonable that we don't necessarily want to accept this patch, but I wanted to get feedback on whether this is something you'd be willing to accept, either in a more completed form, or after we get all the way to certain goals.

This is meant to gesture towards the following goals:
- maintaining backwards compatibility
- moving towards support for Django 1.8
- allowing djangobars to be used in a multi-threaded environment

This work came about when originally trying to deploy djangobars in a multithreaded production environment with high traffic.  Two kinds of errors surfaced that lead to a (temporary) rollback.  The first were context errors -- logic like {{#if foo.bar}} {{foo.bar}} {{/if}} would fail saying 'no foo.bar' exists!  The second is that templates were being outputted in corupted ways.  It became clear that there was a threading issue, and sure-enough, in pybars._compiler, there's a note saying that the Compiler is not thread-safe.

After fixing thread-safety, there was still a big issue with performance.  Locking the threads destroyed the performance value of a threaded environment.  Measuring performance, the bottleneck was compiling the templates.  Thus, the precompilation support.

It is organized as follows:
- In anticipation of Django 1.8 template engine support, it creates a new file template/backends.py with a Handlebars engine structured for the Django 1.8 api (though missing some parts for full support)
- In backends.py there is also a CompiledTemplate which is subclassed from template.base.HandlebarsTemplate
- HandlbarsTemplate and BaseHandlebarsLoader are tweaked to leverage the code in backends.Handlebars.
- loader.reset_loaders is a new method, which helps testing
- loaders.filesystem.CachedLoader is mostly separate, but also helps keep template compilations in cache and reusable for future requests.

Some current issues:
- Although we get pretty far to Django 1.8 support, it's not complete and certainly hasn't been tested.  Besides testing, at minimum the backends.Handlebars.get_template needs to be able to handle a real `dirs` list rather than being passed the legacy loaders objects in its place.  When running the test suite against current django 1.8, we clearly also need to try/catch some django imports that no longer exist there.
- Because of the dual goals of maintaining the old interfaces, along with moving toward Django 1.8, there's a lot of argument passing and not a lot of clarity on which objects are responsible for what.  Firstly, feedback is welcome on how to organize it better.  Second, once we made a 'true' Django 1.8 engine, it might be better, even if we kept the goal of maintaining backward compatibility that the old interfaces just be re-implemented from the engine, rather than what I'm doing which is more the other way around.  Alternatively, we could save that for another day.
- Currently, there's no testing on whether a template has been updated when using the pre-compiled version.  We could leave it that way, and just document, that the user is responsible for clearing the directory when there are updates.  We could also do something fancy with file mtimes and possibly addending the 'full_code' that comes back from pybars.

Originally, I separated the thread safety and precompilation as projects, but in production, we found that locking threads, still blocks too many requests, so they are really necessary combined, at least, in practice.
